### PR TITLE
Fix machine dependent bug

### DIFF
--- a/app/pskr-mqtt-cache/database.py
+++ b/app/pskr-mqtt-cache/database.py
@@ -278,9 +278,7 @@ class SpotDatabase:
 
         try:
             with self._conn() as db:
-                # Use a context manager for the cursor itself
-                with db.execute(sql, params) as cur:
-                    return cur.fetchall()
+                curr = db.execute(sql, params)
                 return cur.fetchall()
         except Exception as exc:
             log.error("Query error: %s", exc)


### PR DESCRIPTION
Now this one I can't figure out. The exact same image on our production machine gives an error that object does not support the context manager protol. It's the same image!

Ok, so remove that.