### PR TITLE
Less aggressive vacuum and refactor base image

### DIFF
--- a/app/pskr-mqtt-cache/database.py
+++ b/app/pskr-mqtt-cache/database.py
@@ -234,7 +234,8 @@ class SpotDatabase:
                     # ensuring the checkpoint runs. This is critical for moving deleted
                     # pages from the WAL to the main DB freelist so that
                     # incremental_vacuum can reclaim the space. It does not block readers.
-                    res = db.execute("PRAGMA wal_checkpoint(FULL)").fetchone()
+                    # We'll use NORMAL to be less aggressive but still make some happen
+                    res = db.execute("PRAGMA wal_checkpoint(NORMAL)").fetchone()
                     if res and res[2] > 0:
                         log.info("Checkpointed %d pages from WAL to main database.", res[2])
                     else:
@@ -307,13 +308,15 @@ class SpotDatabase:
                 original_isolation_level = db.isolation_level
                 db.isolation_level = None
                 try:
-                    # We must consume the result for the pragma to execute.
-                    # When pages is 0 (the default), we want to vacuum all free pages.
-                    # This is achieved by omitting the argument to the pragma, as
-                    # `PRAGMA incremental_vacuum(0)` would vacuum zero pages.
-                    vacuum_sql = "PRAGMA incremental_vacuum"
-                    if pages > 0:
-                        vacuum_sql += f"({pages})"
+                    # When pages is 0 (the default), it would vacuum all
+                    # free pages. But we know it's just going to create more
+                    # so let's just vacuum half.
+                    if pages == 0:
+                        some_pages = before/2 # less aggressively clean
+                        vacuum_sql = f"PRAGMA incremental_vacuum({some_pages})"
+                    else:
+                        vacuum_sql = f"PRAGMA incremental_vacuum({pages})"
+
                     # We must consume all results for the pragma to run to completion.
                     # fetchone() may cause it to stop after processing a small number
                     # of pages. fetchall() ensures the entire freelist is processed.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,32 +1,37 @@
 # ── Stage 1: Build ────────────────────────────────────────────────────────────
 # Install dependencies in a separate stage so build tools don't end up
 # in the final image.
-FROM python:3.12-slim-bookworm AS builder
+FROM debian:13.3-slim AS builder
 
 WORKDIR /build
 
 # Copy and install Python dependencies into a prefix we can copy over
-COPY requirements.txt .
+COPY requirements.txt ./
+COPY docker/package-list-support.txt ./
 # Install build deps needed to compile any C extensions in requirements
-RUN apt-get update && apt-get install -y --no-install-recommends \
-        gcc \
-        libsqlite3-dev \
-    && rm -rf /var/lib/apt/lists/* \
-    && pip install --no-cache-dir --prefix=/install -r requirements.txt
-
+RUN apt update && \
+    apt install -y --no-install-recommends $(grep -v '^#' package-list-support.txt) && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* && \
+    pip install --no-cache-dir --prefix=/install -r requirements.txt
 
 # ── Stage 2: Runtime ──────────────────────────────────────────────────────────
-FROM python:3.12-slim-bookworm AS runtime
+FROM debian:13.3-slim AS runtime
 
-# Keep image up to date with latest Debian security patches at build time
-RUN apt-get update && apt-get upgrade -y --no-install-recommends \
-    && apt-get install -y --no-install-recommends \
-        libsqlite3-0 \
-        ca-certificates \
-    && rm -rf /var/lib/apt/lists/*
+WORKDIR /app
 
 # Copy installed Python packages from builder
-COPY --from=builder /install /usr/local
+COPY --from=builder /install/ /usr/
+COPY docker/package-list.txt ./
+
+# Keep image up to date with latest Debian security patches at build time
+RUN apt update && \
+    apt install -y --no-install-recommends $(grep -v '^#' package-list.txt) && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+# ── Application ───────────────────────────────────────────────────────────────
+COPY app/pskr-mqtt-cache/ ./pskr_mqtt_cache/
 
 # ── Non-root user ─────────────────────────────────────────────────────────────
 # Never run as root inside the container
@@ -38,10 +43,6 @@ RUN groupadd --gid 1001 pskr \
 # /etc/pskr    — config.yaml (mount or COPY at deploy time)
 RUN mkdir -p /data /etc/pskr \
  && chown pskr:pskr /data /etc/pskr
-
-# ── Application ───────────────────────────────────────────────────────────────
-WORKDIR /app
-COPY app/pskr-mqtt-cache/ ./pskr_mqtt_cache/
 
 # Default config — override by mounting /etc/pskr/config.yaml
 COPY config.yaml.example /etc/pskr/config.yaml
@@ -66,6 +67,6 @@ EXPOSE 5000
 VOLUME ["/data"]
 
 HEALTHCHECK --interval=60s --timeout=10s --start-period=15s --retries=3 \
-    CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:5000/status')" || exit 1
+    CMD python3 -c "import urllib.request; urllib.request.urlopen('http://localhost:5000/status')" || exit 1
 
-CMD ["python", "-m", "pskr_mqtt_cache", "--config", "/etc/pskr/config.yaml"]
+CMD ["python3", "-m", "pskr_mqtt_cache", "--config", "/etc/pskr/config.yaml"]

--- a/docker/package-list-support.txt
+++ b/docker/package-list-support.txt
@@ -1,0 +1,9 @@
+# empty lines and lines beginning with a # are ignored. Note that comments within lines are not ignored
+
+# temp for development
+
+# packages required by pskr-mqtt-cache builder
+gcc
+libsqlite3-dev
+python3
+python3-pip

--- a/docker/package-list.txt
+++ b/docker/package-list.txt
@@ -1,0 +1,10 @@
+# empty lines and lines beginning with a # are ignored. Note that comments within lines are not ignored
+
+# temp for development
+vim
+sqlite3
+
+# packages required by pskr-mqtt-cache
+ca-certificates
+libsqlite3-0
+python3


### PR DESCRIPTION
- still working to limit disk pressure
- wal-checkpoint NORMAL to be less aggressive
- vacuum 1/2 of the pages - system immediately needs some so don't get rid of all of them
- refactor dockerfile to use external packages list
- build from debian:13.3-slim to unify with other images