### PR TITLE
Issue 16 coord

### DIFF
--- a/app/pskr-mqtt-cache/config.py
+++ b/app/pskr-mqtt-cache/config.py
@@ -89,6 +89,7 @@ def load(path: str | None = None) -> Config:
             client_id=m.get("client_id", cfg.mqtt.client_id),
             keepalive=int(m.get("keepalive", cfg.mqtt.keepalive)),
             reconnect_delay=int(m.get("reconnect_delay", cfg.mqtt.reconnect_delay)),
+            flush_max_pause=int(m.get("flush_max_pause", cfg.mqtt.flush_max_pau)),
         )
 
     if "database" in raw:
@@ -98,6 +99,7 @@ def load(path: str | None = None) -> Config:
             max_age_hours=int(d.get("max_age_hours", cfg.database.max_age_hours)),
             prune_interval_minutes=int(d.get("prune_interval_minutes", cfg.database.prune_interval_minutes)),
             cache_size_mb=int(d.get("cache_size_mb", cfg.database.cache_size_mb)),
+            insert_lock_timeout=int(d.get("insert_lock_timeout", cfg.database.insert_lock_timeout)),
         )
 
     if "api" in raw:

--- a/app/pskr-mqtt-cache/config.py
+++ b/app/pskr-mqtt-cache/config.py
@@ -89,7 +89,7 @@ def load(path: str | None = None) -> Config:
             client_id=m.get("client_id", cfg.mqtt.client_id),
             keepalive=int(m.get("keepalive", cfg.mqtt.keepalive)),
             reconnect_delay=int(m.get("reconnect_delay", cfg.mqtt.reconnect_delay)),
-            flush_max_pause=int(m.get("flush_max_pause", cfg.mqtt.flush_max_pau)),
+            flush_max_pause=int(m.get("flush_max_pause", cfg.mqtt.flush_max_pause)),
         )
 
     if "database" in raw:

--- a/app/pskr-mqtt-cache/config.py
+++ b/app/pskr-mqtt-cache/config.py
@@ -26,6 +26,7 @@ class MQTTConfig:
     client_id: str = "pskr-mqtt-cache"
     keepalive: int = 60
     reconnect_delay: int = 5
+    flush_max_pause: int = 60
 
 
 @dataclass
@@ -34,7 +35,7 @@ class DatabaseConfig:
     max_age_hours: int = 7
     prune_interval_minutes: int = 15
     cache_size_mb: int = 64
-
+    insert_lock_timeout: int = 10
 
 @dataclass
 class APIConfig:

--- a/app/pskr-mqtt-cache/config.py
+++ b/app/pskr-mqtt-cache/config.py
@@ -38,6 +38,7 @@ class DatabaseConfig:
     prune_interval_minutes: int = 15
     cache_size_mb: int = 64
     insert_lock_timeout: int = 10
+    mmap_size_mb: int = 2048
 
 @dataclass
 class APIConfig:
@@ -104,6 +105,7 @@ def load(path: str | None = None) -> Config:
             prune_interval_minutes=int(d.get("prune_interval_minutes", cfg.database.prune_interval_minutes)),
             cache_size_mb=int(d.get("cache_size_mb", cfg.database.cache_size_mb)),
             insert_lock_timeout=int(d.get("insert_lock_timeout", cfg.database.insert_lock_timeout)),
+            mmap_size_mb=int(d.get("mmap_size_mb", cfg.database.mmap_size_mb)),
         )
 
     if "api" in raw:

--- a/app/pskr-mqtt-cache/config.py
+++ b/app/pskr-mqtt-cache/config.py
@@ -27,6 +27,8 @@ class MQTTConfig:
     keepalive: int = 60
     reconnect_delay: int = 5
     flush_max_pause: int = 60
+    filter_grid: str = ".{4,}"  #grids are minimum 4 characters
+    filter_call: str = ".{3,}"  #calls are minimum 3 characters
 
 
 @dataclass
@@ -90,6 +92,8 @@ def load(path: str | None = None) -> Config:
             keepalive=int(m.get("keepalive", cfg.mqtt.keepalive)),
             reconnect_delay=int(m.get("reconnect_delay", cfg.mqtt.reconnect_delay)),
             flush_max_pause=int(m.get("flush_max_pause", cfg.mqtt.flush_max_pause)),
+            filter_grid=str(m.get("filter_grid", cfg.mqtt.filter_grid)),
+            filter_call=str(m.get("filter_call", cfg.mqtt.filter_call)),            
         )
 
     if "database" in raw:

--- a/app/pskr-mqtt-cache/config.py
+++ b/app/pskr-mqtt-cache/config.py
@@ -22,7 +22,7 @@ class MQTTConfig:
     host: str = "mqtt.pskreporter.info"
     port: int = 1883
     tls: bool = False
-    topic: str = "pskr/filter/v2/#"
+    topic: str | list = "pskr/filter/v2/#"
     client_id: str = "pskr-mqtt-cache"
     keepalive: int = 60
     reconnect_delay: int = 5

--- a/app/pskr-mqtt-cache/database.py
+++ b/app/pskr-mqtt-cache/database.py
@@ -19,8 +19,6 @@ from contextlib import contextmanager
 
 from .config import DatabaseConfig
 
-INSERT_LOCK_TIMEOUT = 10.0  # seconds 
-
 log = logging.getLogger(__name__)
 
 
@@ -32,6 +30,7 @@ class SpotDatabase:
         self.max_age_sec = cfg.max_age_hours * 3600
         self.prune_interval_sec = cfg.prune_interval_minutes * 60
         self.cache_size_kb = cfg.cache_size_mb * 1024
+        self.insert_lock_timeout = cfg.insert_lock_timeout
 
         # Ensure parent directory exists
         Path(self.path).parent.mkdir(parents=True, exist_ok=True)
@@ -57,8 +56,8 @@ class SpotDatabase:
         # NORMAL sync is safe with WAL and much faster than FULL
         db.execute("PRAGMA synchronous=NORMAL")
 
-        # CRITICAL: This allows LIKE 'ABC%' to use indexes. 
-        # Since we store data in UPPER case, this makes grid queries 
+        # CRITICAL: This allows LIKE 'ABC%' to use indexes.
+        # Since we store data in UPPER case, this makes grid queries
         # O(log N) instead of O(N).
         db.execute("PRAGMA case_sensitive_like = ON")
 
@@ -94,6 +93,7 @@ class SpotDatabase:
         is_new = db.execute(
             "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='spots'"
         ).fetchone()[0] == 0
+
         db.execute("""
             CREATE TABLE IF NOT EXISTS spots (
                 sq      INTEGER,                -- PSKReporter sequence number (may be absent)
@@ -115,7 +115,7 @@ class SpotDatabase:
         db.execute("CREATE INDEX IF NOT EXISTS idx_s_grid_t ON spots(s_grid, t)")
         db.execute("CREATE INDEX IF NOT EXISTS idx_r_call_t ON spots(r_call, t)")
         db.execute("CREATE INDEX IF NOT EXISTS idx_s_call_t ON spots(s_call, t)")
-        
+
         # Standalone index for the Pruner
         db.execute("CREATE INDEX IF NOT EXISTS idx_t ON spots(t)")
         db.commit()
@@ -188,7 +188,10 @@ class SpotDatabase:
     def insert_batch(self, spots: list[dict]) -> int:
         """
         Bulk insert a list of spot dicts. Returns number of rows inserted.
-        More efficient than individual inserts for batch backfill.
+        Uses a dedicated short-timeout connection so lock contention with the
+        pruner causes a brief wait (up to self.cfg.insert_lock_timeout seconds) rather
+        than an immediate failure. The pruner releases its lock every 100ms
+        between batches so self.cfg.insert_lock_timeout is ample on SSD.
         """
         if not spots:
             return 0
@@ -225,9 +228,9 @@ class SpotDatabase:
 
         try:
             # Dedicated short-timeout connection — independent of the thread-local
-            # pool so it does not affect the pruner's 30s timeout.
+            # pool so it does not affect the pruner's timeout.
             # WAL mode allows concurrent reads; only writes contend.
-            db = sqlite3.connect(self.path, timeout=INSERT_LOCK_TIMEOUT,
+            db = sqlite3.connect(self.path, timeout=self.insert_lock_timeout,
                                 check_same_thread=False)
             try:
                 db.execute("PRAGMA journal_mode=WAL")
@@ -245,18 +248,33 @@ class SpotDatabase:
             log.error("Batch insert error: %s", exc)
             return 0
 
+    def prune(self, abort_check=None) -> int:
+        """Delete spots older than max_age_sec in batches to avoid long write locks.
 
-
-
-    def prune(self) -> int:
-        """Delete spots older than max_age_sec in batches to avoid long write locks."""
+        abort_check: optional callable — if it returns True the prune loop stops
+                     early and releases the write lock. Remaining old spots are
+                     cleaned up on the next scheduled prune cycle. This prevents
+                     the pruner from holding the lock indefinitely after the flush
+                     thread timeout has fired and inserts need to resume.
+        """
         cutoff = int(time.time()) - self.max_age_sec
         total = 0
         batch_size = 10000
         try:
             while True:
+                # Check abort before acquiring the write lock for the next batch.
+                # abort_check returns True when the flush thread timeout fired —
+                # the pruner yields so inserts can proceed; remaining spots are
+                # cleaned up on the next 10-minute prune cycle.
+                if abort_check and abort_check():
+                    log.info("Prune aborted after %d spots — will resume next cycle.",
+                             total)
+                    break
+
                 with self._conn() as db:
-                    #db.execute("BEGIN IMMEDIATE")
+                    # No BEGIN IMMEDIATE — deferred transaction waits up to
+                    # timeout=30s for write lock. Pruner already has priority
+                    # via the cooperative pause in subscriber.py.
                     cur = db.execute(
                         "DELETE FROM spots WHERE t < ? ORDER BY t ASC LIMIT ?",
                         (cutoff, batch_size)
@@ -266,23 +284,20 @@ class SpotDatabase:
                     total += count
                     if count < batch_size:
                         break
-                # Brief pause between batches to yield to MQTT writer
+
+                # Brief pause between batches to yield write lock to MQTT writer
                 time.sleep(0.10)
+
             if total:
                 log.info("Pruned %d spots older than %dh", total, self.max_age_sec // 3600)
-                # Force a checkpoint to move all that deleted space back to the DB
                 with self._conn() as db:
-                    # Use FULL checkpoint mode. PASSIVE is a no-op if another connection
-                    # is writing, which is likely. FULL waits for writers to finish,
-                    # ensuring the checkpoint runs. This is critical for moving deleted
-                    # pages from the WAL to the main DB freelist so that
-                    # incremental_vacuum can reclaim the space. It does not block readers.
-                    # We'll use NORMAL to be less aggressive but still make some happen
                     res = db.execute("PRAGMA wal_checkpoint(NORMAL)").fetchone()
-                    if res and res[2] > 0: # res[2] is the number of pages checkpointed
+                    if res and res[2] > 0:
                         log.info("Checkpointed %d pages from WAL to main database.", res[2])
                     else:
-                        log.info("WAL checkpoint ran, but no pages were moved (busy=%s, log=%s, checkpointed=%s).", res[0], res[1], res[2]) # res[0]=busy, res[1]=log, res[2]=checkpointed
+                        log.info("WAL checkpoint ran, but no pages were moved "
+                                 "(busy=%s, log=%s, checkpointed=%s).",
+                                 res[0], res[1], res[2])
             return total
         except Exception as exc:
             log.error("Prune error: %s", exc)

--- a/app/pskr-mqtt-cache/database.py
+++ b/app/pskr-mqtt-cache/database.py
@@ -146,6 +146,7 @@ class SpotDatabase:
             rc   = (spot.get("rc") or "").strip().upper()
 
             with self._conn() as db:
+                db.execute("BEGIN IMMEDIATE")
                 cur = db.execute("""
                     INSERT OR IGNORE INTO spots
                         (sq, t, s_grid, s_call, r_grid, r_call, mode, freq, snr)
@@ -207,6 +208,7 @@ class SpotDatabase:
 
         try:
             with self._conn() as db:
+                db.execute("BEGIN IMMEDIATE")
                 cur = db.executemany("""
                     INSERT OR IGNORE INTO spots
                         (sq, t, s_grid, s_call, r_grid, r_call, mode, freq, snr)
@@ -226,6 +228,7 @@ class SpotDatabase:
         try:
             while True:
                 with self._conn() as db:
+                    db.execute("BEGIN IMMEDIATE")
                     cur = db.execute(
                         "DELETE FROM spots WHERE t < ? ORDER BY t ASC LIMIT ?",
                         (cutoff, batch_size)

--- a/app/pskr-mqtt-cache/database.py
+++ b/app/pskr-mqtt-cache/database.py
@@ -19,6 +19,8 @@ from contextlib import contextmanager
 
 from .config import DatabaseConfig
 
+INSERT_LOCK_TIMEOUT = 10.0  # seconds 
+
 log = logging.getLogger(__name__)
 
 
@@ -88,6 +90,10 @@ class SpotDatabase:
             raise
 
     def _init_schema(self, db: sqlite3.Connection):
+        # Check if this is a fresh database before creating anything
+        is_new = db.execute(
+            "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='spots'"
+        ).fetchone()[0] == 0
         db.execute("""
             CREATE TABLE IF NOT EXISTS spots (
                 sq      INTEGER,                -- PSKReporter sequence number (may be absent)
@@ -114,11 +120,21 @@ class SpotDatabase:
         db.execute("CREATE INDEX IF NOT EXISTS idx_t ON spots(t)")
         db.commit()
 
-        # Enable incremental auto_vacuum so freed pages can be reclaimed
-        # without a full VACUUM. Doesn't seem to take before table creation
-        # but with a manual VACUUM it will take.
-        db.execute("PRAGMA auto_vacuum = INCREMENTAL")
-        db.execute("VACUUM")
+        # auto_vacuum must be set after table creation per SQLite docs.
+        # Read current setting:
+        #   0 = NONE, 1 = FULL, 2 = INCREMENTAL
+        current_av = db.execute("PRAGMA auto_vacuum").fetchone()[0]
+        if current_av != 1:  # not already FULL
+            db.execute("PRAGMA auto_vacuum = FULL")
+            db.execute("VACUUM")  # required to activate change on existing db
+            log.info("auto_vacuum changed from %s to FULL — VACUUM complete.",
+                    {0: 'NONE', 2: 'INCREMENTAL'}.get(current_av, current_av))
+        elif is_new:
+            db.execute("PRAGMA auto_vacuum = FULL")
+            db.execute("VACUUM")  # safe on empty db
+            log.info("New database — auto_vacuum=FULL activated.")
+        else:
+            log.info("auto_vacuum=FULL already set — no VACUUM needed.")
         db.commit()
 
     def insert_spot(self, spot: dict) -> bool:
@@ -146,7 +162,8 @@ class SpotDatabase:
             rc   = (spot.get("rc") or "").strip().upper()
 
             with self._conn() as db:
-                db.execute("BEGIN IMMEDIATE")
+                # No BEGIN IMMEDIATE — deferred transaction waits up to
+                # timeout=30s for write lock instead of failing immediately
                 cur = db.execute("""
                     INSERT OR IGNORE INTO spots
                         (sq, t, s_grid, s_call, r_grid, r_call, mode, freq, snr)
@@ -207,8 +224,14 @@ class SpotDatabase:
                 continue
 
         try:
-            with self._conn() as db:
-                db.execute("BEGIN IMMEDIATE")
+            # Dedicated short-timeout connection — independent of the thread-local
+            # pool so it does not affect the pruner's 30s timeout.
+            # WAL mode allows concurrent reads; only writes contend.
+            db = sqlite3.connect(self.path, timeout=INSERT_LOCK_TIMEOUT,
+                                check_same_thread=False)
+            try:
+                db.execute("PRAGMA journal_mode=WAL")
+                db.execute("PRAGMA synchronous=NORMAL")
                 cur = db.executemany("""
                     INSERT OR IGNORE INTO spots
                         (sq, t, s_grid, s_call, r_grid, r_call, mode, freq, snr)
@@ -216,9 +239,14 @@ class SpotDatabase:
                 """, rows)
                 db.commit()
                 return cur.rowcount
+            finally:
+                db.close()
         except Exception as exc:
             log.error("Batch insert error: %s", exc)
             return 0
+
+
+
 
     def prune(self) -> int:
         """Delete spots older than max_age_sec in batches to avoid long write locks."""
@@ -228,7 +256,7 @@ class SpotDatabase:
         try:
             while True:
                 with self._conn() as db:
-                    db.execute("BEGIN IMMEDIATE")
+                    #db.execute("BEGIN IMMEDIATE")
                     cur = db.execute(
                         "DELETE FROM spots WHERE t < ? ORDER BY t ASC LIMIT ?",
                         (cutoff, batch_size)
@@ -239,7 +267,7 @@ class SpotDatabase:
                     if count < batch_size:
                         break
                 # Brief pause between batches to yield to MQTT writer
-                time.sleep(0.05)
+                time.sleep(0.10)
             if total:
                 log.info("Pruned %d spots older than %dh", total, self.max_age_sec // 3600)
                 # Force a checkpoint to move all that deleted space back to the DB
@@ -302,9 +330,22 @@ class SpotDatabase:
         sql += " ORDER BY t DESC"
 
         try:
-            with self._conn() as db:
+            # Dedicated read connection — short timeout since reads should
+            # never block in WAL mode. If they do, return empty rather than
+            # making HamClock wait for the full 30s pruner timeout.
+            db = sqlite3.connect(self.path, timeout=5,
+                                check_same_thread=False)
+            db.row_factory = sqlite3.Row
+            try:
+                db.execute("PRAGMA journal_mode=WAL")
+                db.execute("PRAGMA synchronous=NORMAL")
+                db.execute("PRAGMA case_sensitive_like = ON")
+                db.execute("PRAGMA temp_store=MEMORY")
+                db.execute("PRAGMA query_only=ON")
                 cur = db.execute(sql, params)
                 return cur.fetchall()
+            finally:
+                db.close()
         except Exception as exc:
             log.error("Query error: %s", exc)
             return []

--- a/app/pskr-mqtt-cache/database.py
+++ b/app/pskr-mqtt-cache/database.py
@@ -31,6 +31,7 @@ class SpotDatabase:
         self.prune_interval_sec = cfg.prune_interval_minutes * 60
         self.cache_size_kb = cfg.cache_size_mb * 1024
         self.insert_lock_timeout = cfg.insert_lock_timeout
+        self.mmap_size = cfg.mmap_size_mb * 1024 * 1024         
 
         # Ensure parent directory exists
         Path(self.path).parent.mkdir(parents=True, exist_ok=True)
@@ -72,8 +73,7 @@ class SpotDatabase:
 
         # Use memory-mapped I/O. 2GB is a safe starting point for your Xeon.
         # This significantly reduces CPU cycles spent on I/O.
-        mmap_size = 2 * 1024 * 1024 * 1024
-        db.execute(f"PRAGMA mmap_size={mmap_size}")
+        db.execute(f"PRAGMA mmap_size={self.mmap_size}")
 
         return db
 

--- a/app/pskr-mqtt-cache/main.py
+++ b/app/pskr-mqtt-cache/main.py
@@ -14,6 +14,10 @@ Usage:
 """
 import sys
 import signal
+# Ensure zombie processes are reaped automatically.
+# Uvicorn uses os.fork() internally and without this handler
+# child processes accumulate as zombies.
+signal.signal(signal.SIGCHLD, signal.SIG_DFL)
 import logging
 import argparse
 import uvicorn

--- a/app/pskr-mqtt-cache/main.py
+++ b/app/pskr-mqtt-cache/main.py
@@ -1,28 +1,22 @@
 """
 main.py — Entry point for pskr-mqtt-cache.
-
 Copyright (C) 2026 Open HamClock Backend (OHB) Contributors
 License: GNU Affero General Public License v3.0 (AGPLv3)
 See LICENSE file or <https://www.gnu.org/licenses/agpl-3.0.html>
-
 Starts three concurrent components:
   1. MQTT subscriber thread — receives spots and writes to SQLite
   2. Background pruner thread — removes spots older than max_age_hours
   3. FastAPI/uvicorn HTTP server — serves /spots and /status queries
-
 Usage:
     python -m pskr_mqtt_cache [--config /path/to/config.yaml]
     # or
     python main.py [--config /path/to/config.yaml]
 """
-
 import sys
 import signal
 import logging
 import argparse
-
 import uvicorn
-
 from .config import load as load_config
 from .database import SpotDatabase
 from .subscriber import SpotSubscriber
@@ -45,7 +39,6 @@ def main():
 
     cfg = load_config(args.config)
     setup_logging(cfg.logging.level)
-
     log = logging.getLogger("pskr_mqtt_cache.main")
     log.info("Starting pskr-mqtt-cache")
 
@@ -62,7 +55,9 @@ def main():
     subscriber.start()
 
     # ── Pruner ────────────────────────────────────────────────────────────────
-    pruner = Pruner(db, cfg.database)
+    # Pass subscriber so pruner can coordinate flush pausing to avoid
+    # write lock starvation on busy systems.
+    pruner = Pruner(db, cfg.database, subscriber)
     pruner.start()
 
     # ── Graceful shutdown ─────────────────────────────────────────────────────

--- a/app/pskr-mqtt-cache/pruner.py
+++ b/app/pskr-mqtt-cache/pruner.py
@@ -5,6 +5,8 @@ Copyright (C) 2026 Open HamClock Backend (OHB) Contributors
 License: GNU Affero General Public License v3.0 (AGPLv3)
 See LICENSE file or <https://www.gnu.org/licenses/agpl-3.0.html>
 
+Coordinates with SpotSubscriber to pause the flush thread during pruning
+so the pruner can acquire the SQLite write lock without being starved.
 """
 
 import time
@@ -18,24 +20,37 @@ log = logging.getLogger(__name__)
 
 
 class Pruner:
-    def __init__(self, db: SpotDatabase, cfg: DatabaseConfig):
-        self.db       = db
-        self.interval = cfg.prune_interval_minutes * 60
-        self._running = False
+    def __init__(self, db: SpotDatabase, cfg: DatabaseConfig, subscriber=None):
+        self.db         = db
+        self.subscriber = subscriber   # SpotSubscriber reference for flush coordination
+        self.interval   = cfg.prune_interval_minutes * 60
+        self._running   = False
         self._stop_event = threading.Event()
-        self._thread  = None
+        self._thread    = None
 
     def _run(self):
         log.info("Pruner started (interval=%ds)", self.interval)
-        # Prune immediately on startup to clean stale data from volume
+        # Prune immediately on startup to clean stale data from volume.
+        # No need to pause flush thread here — it hasn't built up a backlog yet.
         self.db.prune()
         self.db.incremental_vacuum()
         while self._running:
             if self._stop_event.wait(self.interval):
                 break
             if self._running:
-                self.db.prune()
-                self.db.incremental_vacuum()
+                # Pause the flush thread so pruner can acquire the write lock.
+                # Without this, the flush thread's BEGIN IMMEDIATE every 15s
+                # starves the pruner indefinitely.
+                if self.subscriber:
+                    self.subscriber.pause_for_prune()
+                    time.sleep(0.2)   # let any in-flight flush commit finish
+                try:
+                    self.db.prune()
+                    self.db.incremental_vacuum()
+                finally:
+                    # Always resume even if prune raised an exception
+                    if self.subscriber:
+                        self.subscriber.resume_after_prune()
 
     def start(self):
         self._running = True

--- a/app/pskr-mqtt-cache/pruner.py
+++ b/app/pskr-mqtt-cache/pruner.py
@@ -7,6 +7,11 @@ See LICENSE file or <https://www.gnu.org/licenses/agpl-3.0.html>
 
 Coordinates with SpotSubscriber to pause the flush thread during pruning
 so the pruner can acquire the SQLite write lock without being starved.
+
+When the flush thread timeout fires (MAX_PAUSE_SECONDS exceeded), the pruner
+detects this via abort_check() and stops batching immediately, releasing the
+write lock so inserts can resume. Remaining old spots are cleaned up on the
+next scheduled prune cycle.
 """
 
 import time
@@ -28,6 +33,16 @@ class Pruner:
         self._stop_event = threading.Event()
         self._thread    = None
 
+    def _abort_prune(self) -> bool:
+        """Return True if the pruner should stop batching.
+
+        Fires when the flush thread timeout has cleared _paused_for_prune —
+        meaning inserts need to resume and the pruner should release the
+        write lock. Remaining old spots are cleaned on the next cycle.
+        """
+        return (self.subscriber is not None and
+                not self.subscriber._paused_for_prune.is_set())
+
     def _run(self):
         log.info("Pruner started (interval=%ds)", self.interval)
         first_run = True
@@ -36,16 +51,24 @@ class Pruner:
                 paused = False
                 try:
                     # Skip pause on startup — flush thread has no backlog yet
-                    # and pausing risks OOM if startup prune takes a long time
+                    # and pausing risks OOM if startup prune takes a long time.
+                    # abort_check is also skipped on first_run since the pause
+                    # flag is not set — no timeout can fire.
                     if self.subscriber and not first_run:
                         self.subscriber.pause_for_prune()
                         paused = True
-                        time.sleep(0.5)
-                    self.db.prune()
-                    #self.db.incremental_vacuum()
+                        time.sleep(0.5)   # let any in-flight flush commit finish
+
+                    # Pass abort_check only for scheduled prune cycles (not startup).
+                    # On startup the flush thread is not paused so abort_check
+                    # would immediately abort — not what we want.
+                    abort = self._abort_prune if (self.subscriber and not first_run) else None
+                    self.db.prune(abort_check=abort)
+
                 except Exception as exc:
                     log.error("Pruner error: %s", exc)
                 finally:
+                    # Always resume flush thread even if prune raised an exception
                     if paused and self.subscriber:
                         try:
                             self.subscriber.resume_after_prune()

--- a/app/pskr-mqtt-cache/pruner.py
+++ b/app/pskr-mqtt-cache/pruner.py
@@ -42,7 +42,7 @@ class Pruner:
                         paused = True
                         time.sleep(0.5)
                     self.db.prune()
-                    self.db.incremental_vacuum()
+                    #self.db.incremental_vacuum()
                 except Exception as exc:
                     log.error("Pruner error: %s", exc)
                 finally:

--- a/app/pskr-mqtt-cache/pruner.py
+++ b/app/pskr-mqtt-cache/pruner.py
@@ -30,27 +30,30 @@ class Pruner:
 
     def _run(self):
         log.info("Pruner started (interval=%ds)", self.interval)
-        # Prune immediately on startup to clean stale data from volume.
-        # No need to pause flush thread here — it hasn't built up a backlog yet.
-        self.db.prune()
-        self.db.incremental_vacuum()
+        first_run = True
         while self._running:
-            if self._stop_event.wait(self.interval):
-                break
             if self._running:
-                # Pause the flush thread so pruner can acquire the write lock.
-                # Without this, the flush thread's BEGIN IMMEDIATE every 15s
-                # starves the pruner indefinitely.
-                if self.subscriber:
-                    self.subscriber.pause_for_prune()
-                    time.sleep(0.2)   # let any in-flight flush commit finish
+                paused = False
                 try:
+                    # Skip pause on startup — flush thread has no backlog yet
+                    # and pausing risks OOM if startup prune takes a long time
+                    if self.subscriber and not first_run:
+                        self.subscriber.pause_for_prune()
+                        paused = True
+                        time.sleep(0.5)
                     self.db.prune()
                     self.db.incremental_vacuum()
+                except Exception as exc:
+                    log.error("Pruner error: %s", exc)
                 finally:
-                    # Always resume even if prune raised an exception
-                    if self.subscriber:
-                        self.subscriber.resume_after_prune()
+                    if paused and self.subscriber:
+                        try:
+                            self.subscriber.resume_after_prune()
+                        except Exception as exc:
+                            log.error("Failed to resume flush thread: %s", exc)
+                first_run = False
+            if self._stop_event.wait(self.interval):
+                break
 
     def start(self):
         self._running = True

--- a/app/pskr-mqtt-cache/subscriber.py
+++ b/app/pskr-mqtt-cache/subscriber.py
@@ -31,6 +31,7 @@ log = logging.getLogger(__name__)
 
 FLUSH_INTERVAL = 15    # seconds between batch flushes
 FLUSH_SIZE     = 5000  # flush early if batch reaches this size
+MAX_PAUSE_SECONDS = 30 # Maximum time to pause flush (seconds)
 
 
 class SpotSubscriber:
@@ -51,6 +52,7 @@ class SpotSubscriber:
 
         # Pruner coordination — set by Pruner to pause flush during prune
         self._paused_for_prune = threading.Event()
+        self._pause_start = None
 
         self._client      = None
 
@@ -126,30 +128,34 @@ class SpotSubscriber:
             self.spots_inserted += inserted
 
     def _flush_loop(self):
-        """Background thread that flushes the batch every FLUSH_INTERVAL seconds."""
-        log.info("Flush thread started (interval=%ds, max_batch=%d)",
-                 FLUSH_INTERVAL, FLUSH_SIZE)
         while self._running:
             if self._stop_event.wait(FLUSH_INTERVAL):
                 break
-            # Skip flush if pruner has requested a pause so it can acquire
-            # the SQLite write lock without being starved by our BEGIN IMMEDIATE.
-            if self._running and not self._paused_for_prune.is_set():
-                self._flush()
-        # Final flush on shutdown
-        self._flush()
-        log.info("Flush thread stopped.")
+            if self._running:
+                # Auto-resume if pruner has been holding pause too long
+                if self._paused_for_prune.is_set():
+                    pause_duration = time.time() - (self._pause_start or time.time())
+                    if pause_duration > MAX_PAUSE_SECONDS:
+                        log.warning("Pruner pause timeout (%ds) — forcing flush resume",
+                                    int(pause_duration))
+                        self._paused_for_prune.clear()
+                        self._pause_start = None
+                if not self._paused_for_prune.is_set():
+                    self._flush()  
+        
 
     # ── Pruner Coordination ───────────────────────────────────────────────────
 
     def pause_for_prune(self):
         """Signal flush thread to pause while pruner acquires write lock."""
         self._paused_for_prune.set()
+        self._pause_start = time.time()    # record when pause started
         log.info("Flush thread paused for pruner.")
 
     def resume_after_prune(self):
         """Resume flush thread after pruner completes."""
         self._paused_for_prune.clear()
+        self._pause_start = None           # clear the timer
         log.info("Flush thread resumed after pruner.")
 
     # ── Lifecycle ─────────────────────────────────────────────────────────────

--- a/app/pskr-mqtt-cache/subscriber.py
+++ b/app/pskr-mqtt-cache/subscriber.py
@@ -31,7 +31,6 @@ log = logging.getLogger(__name__)
 
 FLUSH_INTERVAL = 15    # seconds between batch flushes
 FLUSH_SIZE     = 5000  # flush early if batch reaches this size
-MAX_PAUSE_SECONDS = 30 # Maximum time to pause flush (seconds)
 
 
 class SpotSubscriber:
@@ -135,8 +134,8 @@ class SpotSubscriber:
                 # Auto-resume if pruner has been holding pause too long
                 if self._paused_for_prune.is_set():
                     pause_duration = time.time() - (self._pause_start or time.time())
-                    if pause_duration > MAX_PAUSE_SECONDS:
-                        log.warning("Pruner pause timeout (%ds) — forcing flush resume",
+                    if pause_duration > self.cfg.flush_max_pause:
+                        log.info("Pruner pause timeout (%ds) — forcing flush resume",
                                     int(pause_duration))
                         self._paused_for_prune.clear()
                         self._pause_start = None

--- a/app/pskr-mqtt-cache/subscriber.py
+++ b/app/pskr-mqtt-cache/subscriber.py
@@ -26,6 +26,7 @@ import paho.mqtt.client as mqtt
 
 from .config import MQTTConfig
 from .database import SpotDatabase
+import re
 
 log = logging.getLogger(__name__)
 
@@ -60,6 +61,12 @@ class SpotSubscriber:
         self.spots_inserted  = 0
         self.last_spot_time  = None
         self.connect_time    = None
+        
+        # filters
+        self.spots_filtered = 0
+        self._grid_re = re.compile(self.cfg.filter_grid, re.IGNORECASE)
+        self._call_re = re.compile(self.cfg.filter_call, re.IGNORECASE)
+        log.info("subscriber init: grid_filter='%s' call_filter='%s'",self.cfg.filter_grid, self.cfg.filter_call)        
 
     # ── MQTT Callbacks ────────────────────────────────────────────────────────
 
@@ -94,7 +101,24 @@ class SpotSubscriber:
         # Skip spots missing both grids — HamClock requires at least one
         if not spot.get("sl") and not spot.get("rl"):
             return
-
+            
+        # Apply grid and call filters — spot passes if ANY of the four fields match
+        sl = spot.get("sl") or ""
+        rl = spot.get("rl") or ""
+        sc = spot.get("sc") or ""
+        rc = spot.get("rc") or ""
+        
+        if not (self._grid_re.search(sl) or
+                self._grid_re.search(rl) or
+                self._call_re.search(sc) or
+                self._call_re.search(rc)):
+            self.spots_filtered += 1    
+            if self.spots_filtered % 10000 == 0:
+                log.info("Stats filtered: received=%d, filtered=%d",
+                         self.spots_received, self.spots_filtered)
+            return        
+        
+        
         # Append to batch — lock is brief (list append is O(1))
         with self._batch_lock:
             self._batch.append(spot)
@@ -107,8 +131,8 @@ class SpotSubscriber:
 
         # Periodic stats log
         if self.spots_received % 10000 == 0:
-            log.info("Stats: received=%d inserted=%d",
-                     self.spots_received, self.spots_inserted)
+            log.info("Stats: received=%d filtered=%d inserted=%d",
+                     self.spots_received, self.spots_filtered, self.spots_inserted)
 
     # ── Batch Flush ───────────────────────────────────────────────────────────
 
@@ -141,7 +165,8 @@ class SpotSubscriber:
                         self._pause_start = None
                 if not self._paused_for_prune.is_set():
                     self._flush()  
-        
+                    log.info("Flushing stats: received=%d filtered=%d inserted=%d",
+                             self.spots_received, self.spots_filtered, self.spots_inserted)        
 
     # ── Pruner Coordination ───────────────────────────────────────────────────
 
@@ -224,5 +249,6 @@ class SpotSubscriber:
             "connect_time":    self.connect_time,
             "spots_received":  self.spots_received,
             "spots_inserted":  self.spots_inserted,
+            "spots_filtered":  self.spots_filtered,            
             "last_spot_time":  self.last_spot_time,
         }

--- a/app/pskr-mqtt-cache/subscriber.py
+++ b/app/pskr-mqtt-cache/subscriber.py
@@ -45,6 +45,7 @@ class SpotSubscriber:
         # In-memory batch — MQTT callback appends here, flush thread drains it
         self._batch       = []
         self._batch_lock  = threading.Lock()
+        self._flush_lock  = threading.Lock()
         self._flush_thread = None
         self._stop_event  = threading.Event()
         self._client      = None
@@ -107,14 +108,17 @@ class SpotSubscriber:
 
     def _flush(self):
         """Drain the batch and write to SQLite."""
-        with self._batch_lock:
-            if not self._batch:
-                return
-            batch = self._batch
-            self._batch = []
+        # The flush_lock ensures that the timer thread and the buffer-full
+        # logic don't attempt to write to the database simultaneously.
+        with self._flush_lock:
+            with self._batch_lock:
+                if not self._batch:
+                    return
+                batch = self._batch
+                self._batch = []
 
-        inserted = self.db.insert_batch(batch)
-        self.spots_inserted += inserted
+            inserted = self.db.insert_batch(batch)
+            self.spots_inserted += inserted
 
     def _flush_loop(self):
         """Background thread that flushes the batch every FLUSH_INTERVAL seconds."""

--- a/app/pskr-mqtt-cache/subscriber.py
+++ b/app/pskr-mqtt-cache/subscriber.py
@@ -48,6 +48,10 @@ class SpotSubscriber:
         self._flush_lock  = threading.Lock()
         self._flush_thread = None
         self._stop_event  = threading.Event()
+
+        # Pruner coordination — set by Pruner to pause flush during prune
+        self._paused_for_prune = threading.Event()
+
         self._client      = None
 
         # Stats
@@ -96,8 +100,9 @@ class SpotSubscriber:
             batch_size = len(self._batch)
 
         # Flush early if batch is large enough
-        if batch_size >= FLUSH_SIZE:
+        if batch_size >= FLUSH_SIZE and not self._paused_for_prune.is_set():
             self._flush()
+
 
         # Periodic stats log
         if self.spots_received % 10000 == 0:
@@ -127,11 +132,25 @@ class SpotSubscriber:
         while self._running:
             if self._stop_event.wait(FLUSH_INTERVAL):
                 break
-            if self._running:
+            # Skip flush if pruner has requested a pause so it can acquire
+            # the SQLite write lock without being starved by our BEGIN IMMEDIATE.
+            if self._running and not self._paused_for_prune.is_set():
                 self._flush()
         # Final flush on shutdown
         self._flush()
         log.info("Flush thread stopped.")
+
+    # ── Pruner Coordination ───────────────────────────────────────────────────
+
+    def pause_for_prune(self):
+        """Signal flush thread to pause while pruner acquires write lock."""
+        self._paused_for_prune.set()
+        log.info("Flush thread paused for pruner.")
+
+    def resume_after_prune(self):
+        """Resume flush thread after pruner completes."""
+        self._paused_for_prune.clear()
+        log.info("Flush thread resumed after pruner.")
 
     # ── Lifecycle ─────────────────────────────────────────────────────────────
 

--- a/app/pskr-mqtt-cache/subscriber.py
+++ b/app/pskr-mqtt-cache/subscriber.py
@@ -75,8 +75,14 @@ class SpotSubscriber:
             self._connected   = True
             self.connect_time = time.time()
             log.info("Connected to MQTT broker %s:%d", self.cfg.host, self.cfg.port)
-            client.subscribe(self.cfg.topic)
-            log.info("Subscribed to topic: %s", self.cfg.topic)
+            # Support single topic string or list of topics
+            topics = self.cfg.topic if isinstance(self.cfg.topic, list) else [self.cfg.topic]
+            for topic in topics:
+                try:
+                    client.subscribe(topic)
+                    log.info("Subscribed to topic: %s", topic)
+                except Exception as exc:
+                    log.error("Failed to subscribe to topic %s: %s", topic, exc)
         else:
             log.error("MQTT connect failed, rc=%d", rc)
 

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -13,14 +13,16 @@ mqtt:
   client_id: "pskr-mqtt-cache"
   keepalive: 60
   reconnect_delay: 5   # seconds between reconnect attempts
+  flush_max_pause: 60  # seconds maximum time to pause flushing for pruner
 
 database:
   path: /data/spots.db
   max_age_hours: 7
-  prune_interval_minutes: 10
+  prune_interval_minutes: 5
   # WAL mode is always enabled for concurrent read/write performance
   cache_size_mb: 64
-
+  insert_lock_timeout: 10    # seconds to wait for db lock for insert_batch
+  
 api:
   host: 0.0.0.0
   port: 5000

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -25,6 +25,7 @@ database:
   # WAL mode is always enabled for concurrent read/write performance
   cache_size_mb: 64
   insert_lock_timeout: 10    # seconds to wait for db lock for insert_batch
+  mmap_size_mb: 2048
   
 api:
   host: 0.0.0.0

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -14,6 +14,9 @@ mqtt:
   keepalive: 60
   reconnect_delay: 5   # seconds between reconnect attempts
   flush_max_pause: 60  # seconds maximum time to pause flushing for pruner
+# if any of sending or receiving grids or call filter regex below match, spot is added to database. ^ start, $ end
+  filter_grid: ".{3,}"   # default ".{3,}" 3 characters min 
+  filter_call: ".{4,}"   # default ".{4,}" 4 characters min
 
 database:
   path: /data/spots.db

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -9,14 +9,28 @@ mqtt:
   host: mqtt.pskreporter.info
   port: 1883           # 1883=plain, 1884=TLS, 1885=WS, 1886=WS+TLS
   tls: false
-  topic: "pskr/filter/v2/#"   # full firehose
+  # topic is a list or string
+  # format pskr/filter/v2/band/mode/sc/rc/sl/rl/sa/ra
+  # string value for full firehose
+  #topic: "pskr/filter/v2/#"   # full firehose
+  # list values for grid and call filters on server, e.g. EM13, KR8X
+  #topic:
+  #  - "pskr/filter/v2/+/+/+/+/EM13/#"
+  #  - "pskr/filter/v2/+/+/+/+/+/EM13/#"  
+  #  - "pskr/filter/v2/+/+/KR8X/+/+/#"
+  #  - "pskr/filter/v2/+/+/+/KR8X/+/+/#"    
+  topic:
+    - "pskr/filter/v2/+/+/+/+/EM13/#"
+    - "pskr/filter/v2/+/+/+/+/+/EM13/#"  
+    - "pskr/filter/v2/+/+/KR8X/+/+/#"
+    - "pskr/filter/v2/+/+/+/KR8X/+/+/#"     
   client_id: "pskr-mqtt-cache"
   keepalive: 60
   reconnect_delay: 5   # seconds between reconnect attempts
   flush_max_pause: 60  # seconds maximum time to pause flushing for pruner
 # if any of sending or receiving grids or call filter regex below match, spot is added to database. ^ start, $ end
-  filter_grid: ".{3,}"   # default ".{3,}" 3 characters min 
-  filter_call: ".{4,}"   # default ".{4,}" 4 characters min
+  filter_grid: ".{4,}"   # default ".{4,}" 4 characters min 
+  filter_call: ".{3,}"   # default ".{3,}" 3 characters min
 
 database:
   path: /data/spots.db
@@ -25,7 +39,8 @@ database:
   # WAL mode is always enabled for concurrent read/write performance
   cache_size_mb: 64
   insert_lock_timeout: 10    # seconds to wait for db lock for insert_batch
-  mmap_size_mb: 2048
+  mmap_size_mb: 2048    # default for high capacity server
+  #mmap_size_mb: 512    # Tested value for Pi 4B for filtered stream  
   
 api:
   host: 0.0.0.0


### PR DESCRIPTION
Add coordination between pruner and subscriber so that pruner can pause flush by subscriber while pruner is performing a prune

running on pi 4b 4gb with performance SD card

resolves memory and disk issue reported here. 
https://github.com/openhamclock/pskr-mqtt-cache/issues/16

docker log:

  2026-05-20T14:05:10 [pskr_mqtt_cache.subscriber] INFO Stats: received=650000 inserted=647943
  2026-05-20T14:05:33 [pskr_mqtt_cache.subscriber] INFO Stats: received=660000 inserted=656917
  2026-05-20T14:05:33 [pskr_mqtt_cache.subscriber] INFO Flush thread paused for pruner.
  2026-05-20T14:05:33 [pskr_mqtt_cache.subscriber] INFO Flush thread resumed after pruner.
  2026-05-20T14:06:00 [pskr_mqtt_cache.subscriber] INFO Stats: received=670000 inserted=666917
  2026-05-20T14:06:37 [pskr_mqtt_cache.subscriber] INFO Stats: received=680000 inserted=679800
  2026-05-20T14:07:05 [pskr_mqtt_cache.subscriber] INFO Stats: received=690000 inserted=689797
  skip 
  2026-05-20T14:15:33 [pskr_mqtt_cache.subscriber] INFO Flush thread paused for pruner.
  2026-05-20T14:15:34 [pskr_mqtt_cache.database] INFO Pruned 3 spots older than 7h
  2026-05-20T14:15:34 [pskr_mqtt_cache.database] INFO Checkpointed 19 pages from WAL to main database.
  2026-05-20T14:15:34 [pskr_mqtt_cache.subscriber] INFO Flush thread resumed after pruner.
  2026-05-20T14:15:55 [pskr_mqtt_cache.subscriber] INFO Stats: received=860000 inserted=858527
  2026-05-20T14:16:23 [pskr_mqtt_cache.subscriber] INFO Stats: received=870000 inserted=868527
  2026-05-20T14:16:56 [pskr_mqtt_cache.subscriber] INFO Stats: received=880000 inserted=878537

This will prevent increasing memory and disk utilization.  This is what it looked like before change.  SD card used to
show memory and disk leak on slow systems.

  $ date && docker stats --no-stream
  Wed 20 May 03:08:04 CDT 2026
  CONTAINER ID   NAME              CPU %     MEM USAGE / LIMIT     MEM %     NET I/O           BLOCK I/O         PIDS
  c2735285f963   pskr-mqtt-cache   94.68%    1.452GiB / 3.708GiB   39.15%    44.9MB / 1.11MB   7.72GB / 9.19GB   5
  dave@kr8xohb1:~ $ docker stop pskr-mqtt-cache
  pskr-mqtt-cache
  dave@kr8xohb1:~ $MOUNT=$(docker volume inspect ohb-htdocs --format '{{.Mountpoint}}')
sudo ls -l $MOUNT/pskr
total 5469992
-rw-r--r-- 1 1001 1001  539942912 May 20 03:08 spots.db
-rw-r--r-- 1 1001 1001    4915200 May 20 03:11 spots.db-shm
-rw-r--r-- 1 1001 1001 5056401872 May 20 03:08 spots.db-wal

